### PR TITLE
Clarify age as being usage based

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Usage
       -h, --help                Show context-sensitive help (also try --help-long
                                 and --help-man).
           --version             Show application version.
-      -m, --max-image-age=168h  How old to allow images to be before deletion. (Env:
+      -m, --max-image-age=168h  How long to allow images to be unused before deletion. (Env:
                                 DOCKER_GC_MAX_IMAGE_AGE)
       -s, --sweeper-time=15m    How much time between running checks to delete
                                 images. (Env: DOCKER_GC_SWEEPER_TIME)


### PR DESCRIPTION
The killer feature of docker-gc is that the age is based on last used rather than creation.

This should be fairly explicit in the documentation, age makes it sound like time since creation.